### PR TITLE
flyboys fix for some docker issues

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -51,5 +51,5 @@ async def handle_message(payload:Request):
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=1337)
+    uvicorn.run(app, host="0.0.0.0", port=1336)
 

--- a/db-api/src/main.py
+++ b/db-api/src/main.py
@@ -157,5 +157,5 @@ async def get_token(payload:Request):
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="127.0.0.1", port=1337)
+    uvicorn.run(app, host="0.0.0.0", port=1337)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         ports: 
             - "6667:6667"
         depends_on:
+            - chat_input_handler
             - backend
     
     chat_input_handler:
@@ -29,7 +30,6 @@ services:
         ports:
             - "443"
         depends_on:
-            - twitch_chat_reader
             - backend
 
     backend:
@@ -39,6 +39,8 @@ services:
         environment:
             - DB_API_NAME=db_api
             - DB_API_PORT=1337
+        ports:
+            - "1336:1336"            
         restart: on-failure
         networks:
             stream-net:


### PR DESCRIPTION
Changed the order of the dependancies. Twitch chat reader should depend on chat-input-handler... without that the service is useless. 

Changed the backend container to use an assigned port (choose 1336 at random).


I would recommend pulling this branch and test, instead of merging and using to see if it resolve the issues you were having at the end of the last stream. 